### PR TITLE
Rewording post to fit code.

### DIFF
--- a/src/pages/02-first-grid.js
+++ b/src/pages/02-first-grid.js
@@ -17,7 +17,7 @@ const Tutorial = () => (
 
     <h4>Define rows and columns</h4>
     <p>
-      There are several ways to define rows and columns. For our first grid, we will use properties 
+      There are several ways to define rows and columns. For our first grid, we will use properties{' '}
       <code>grid-template-columns</code> and <code>grid-template-rows</code>. These properties allow
       us to define the size of the rows and columns for our grid. To create two fixed-height rows
       of 150px and three fixed-width columns of 150px, simply write:

--- a/src/pages/02-first-grid.js
+++ b/src/pages/02-first-grid.js
@@ -17,7 +17,7 @@ const Tutorial = () => (
 
     <h4>Define rows and columns</h4>
     <p>
-      There are several ways to define rows and columns. For our first grid, we will use properties
+      There are several ways to define rows and columns. For our first grid, we will use properties 
       <code>grid-template-columns</code> and <code>grid-template-rows</code>. These properties allow
       us to define the size of the rows and columns for our grid. To create two fixed-height rows
       of 150px and three fixed-width columns of 150px, simply write:

--- a/src/pages/02-first-grid.js
+++ b/src/pages/02-first-grid.js
@@ -19,7 +19,7 @@ const Tutorial = () => (
     <p>
       There are several ways to define rows and columns. For our first grid, we will use properties
       <code>grid-template-columns</code> and <code>grid-template-rows</code>. These properties allow
-      us to define the size of the rows and columns for our grid. To create three fixed-height rows
+      us to define the size of the rows and columns for our grid. To create two fixed-height rows
       of 150px and three fixed-width columns of 150px, simply write:
     </p>
 
@@ -34,7 +34,7 @@ grid-template-rows: 150px 150px;
 
     <CodeBlock>
       {`
-grid-template-columns: 150px 150px 70px;
+grid-template-columns: 150px 150px 150px 70px;
       `}
     </CodeBlock>
 


### PR DESCRIPTION
I believe this was messed up? I might be missing something about the spec.


1) Here it says "To create three fixed-height rows" but we are actually creating two. 
https://github.com/MozillaDevelopers/playground/blob/master/src/pages/02-first-grid.js#L22


2) It seems that if you have: `grid-template-columns: 150px 150px 70px;` then it would only have three columns. To meet the text in the post of 'fourth' it would need to have an additional `150px`, or say 'third'. 
https://github.com/MozillaDevelopers/playground/blob/master/src/pages/02-first-grid.js#L33
https://github.com/MozillaDevelopers/playground/blob/master/src/pages/02-first-grid.js#L37

3) There was a missing space due to indenting for character limits on each line I'm assuming. Added one in.

Thanks for creating this site! It's very helpful. 

If there is an issue I am happy to make the language consistent across this page in the direction the maintainer wants to go in so this can get merged in. :) 