### PR TITLE
Add fourth column to grid example. Fixes #2.

### DIFF
--- a/src/pages/02-first-grid.js
+++ b/src/pages/02-first-grid.js
@@ -34,7 +34,7 @@ grid-template-rows: 150px 150px;
 
     <CodeBlock>
       {`
-grid-template-columns: 150px 150px 70px;
+grid-template-columns: 150px 150px 150px 70px;
       `}
     </CodeBlock>
 


### PR DESCRIPTION
Add fourth column to example to match example text above.