### PR TITLE
Container name corrections

### DIFF
--- a/src/pages/06-position-items.js
+++ b/src/pages/06-position-items.js
@@ -46,7 +46,7 @@ const Tutorial = () => (
 
     <CodeBlock>
       {`
-<div class="container-6">
+<div class="container">
   <div class="item item1">1</div>
   <div class="item item2">2</div>
   <div class="item item3">3</div>

--- a/src/pages/07-basic-layout.js
+++ b/src/pages/07-basic-layout.js
@@ -34,7 +34,7 @@ const Tutorial = () => (
 
     <CodeBlock>
       {`
-.main {
+.container {
   display: grid;
   width: 750px;
   height: 600px;


### PR DESCRIPTION
Hi -- I fixed two instances of the `container` class in the code example not matching up with the CSS provided. The first is on the page __position items__ where the div has class `container-6`, but if you were following along you would've written a CSS class `container`. I think this was just because the actual rendered HTML had that class so it was probably just copy-pasted.

The second was on the next page where the HTML had class `main` but the CSS example that properly styled it had class `container`. I switched the HTML to keep it consistent with the rest of the tutorial's naming conventions. 

I ran `npm run build` before committing so I hope it's built properly, I apologize if I did it wrong, I've never worked with Gatsby before. 

Thank you so much for all you do for the community, it's invaluable to people like me. 