### PR TITLE
fixed the missing item class in html examples of two pages

### DIFF
--- a/src/pages/css-grid/07-basic-layout.js
+++ b/src/pages/css-grid/07-basic-layout.js
@@ -21,12 +21,12 @@ const Tutorial = () => (
     <CodeBlock>
       {`
 <div class="container">
-  <div class="header">header</div>
-  <div class="sidebar">sidebar</div>
-  <div class="content-1">Content-1</div>
-  <div class="content-2">Content-2</div>
-  <div class="content-3">Content-3</div>
-  <div class="footer">footer</div>
+  <div class="item header">header</div>
+  <div class="item sidebar">sidebar</div>
+  <div class="item content-1">Content-1</div>
+  <div class="item content-2">Content-2</div>
+  <div class="item content-3">Content-3</div>
+  <div class="item footer">footer</div>
 </div>
       `}
     </CodeBlock>

--- a/src/pages/css-grid/08-template-areas.js
+++ b/src/pages/css-grid/08-template-areas.js
@@ -41,12 +41,12 @@ const Tutorial = () => (
     <CodeBlock>
       {`
 <div class="container">
-  <div class="header">header</div>
-  <div class="sidebar">sidebar</div>
-  <div class="content-1">Content-1</div>
-  <div class="content-2">Content-2</div>
-  <div class="content-3">Content-3</div>
-  <div class="footer">footer</div>
+  <div class="item header">header</div>
+  <div class="item sidebar">sidebar</div>
+  <div class="item content-1">Content-1</div>
+  <div class="item content-2">Content-2</div>
+  <div class="item content-3">Content-3</div>
+  <div class="item footer">footer</div>
 </div>
       `}
     </CodeBlock>


### PR DESCRIPTION
I noticed on these two pages that the example HTML is missing the "item" class on six lines:

https://mozilladevelopers.github.io/playground/css-grid/07-basic-layout
https://mozilladevelopers.github.io/playground/css-grid/08-template-areas

This is inconsistent with the rest of the code on the page and in the codepen pages.

This pull request changes the six lines on each page to add the missing "item" class in the HTML example.