### PR TITLE
Remove quoting typos in console.log example

### DIFF
--- a/src/pages/debugger/02-check-variable-values.js
+++ b/src/pages/debugger/02-check-variable-values.js
@@ -53,11 +53,11 @@ const addTodo = e => {
   const title = document.querySelector(".todo__input");
   console.log('title is: ', title);
   const todo = { title };
-  console.log('todo is: ', todo');
+  console.log('todo is: ', todo);
   
   items.push(todo);
   saveList();
-  console.log(‘The updated to-do list is: ‘, items);
+  console.log('The updated to-do list is: ', items);
   document.querySelector(".todo__add").reset();
 };
       `}


### PR DESCRIPTION
Since the example is to add `console.log()` calls to trace, the intent of the example is likely not to have the logging itself be the bug.

Also removed the curly quotes, I don't think that was intentional either.