### PR TITLE
change color to make spaces more distinguishable

### DIFF
--- a/src/components/img/terms/gutter.svg
+++ b/src/components/img/terms/gutter.svg
@@ -9,7 +9,7 @@
             <g id="Group-14" transform="translate(153.000000, 138.000000)">
                 <g id="Group-10" transform="translate(0.000000, 1133.000000)">
                     <g id="Group-4">
-                        <rect id="Rectangle-3" fill="#FF9400" opacity="0.6" transform="translate(62.500000, 61.500000) scale(-1, 1) translate(-62.500000, -61.500000) " x="58" y="0" width="9" height="123"></rect>
+                        <rect id="Rectangle-3" fill="#FFEA49" opacity="0.6" transform="translate(62.500000, 61.500000) scale(-1, 1) translate(-62.500000, -61.500000) " x="58" y="0" width="9" height="123"></rect>
                         <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="2" y="2" width="56" height="53.7705726" rx="2"></rect>
                         <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="69" y="2" width="56" height="53.7705726" rx="2"></rect>
                         <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="135" y="2" width="56" height="53.7705726" rx="2"></rect>

--- a/src/components/img/terms/track.svg
+++ b/src/components/img/terms/track.svg
@@ -13,7 +13,7 @@
                     <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="135" y="2" width="56" height="53.7705726" rx="2"></rect>
                     <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="2" y="67" width="56" height="53.7705726" rx="2"></rect>
                     <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="69" y="67" width="56" height="54" rx="2"></rect>
-                    <rect id="Rectangle-3" fill="#FF9400" opacity="0.6" x="67" y="0" width="60" height="123"></rect>
+                    <rect id="Rectangle-3" fill="#FFEA49" opacity="0.6" x="67" y="0" width="60" height="123"></rect>
                     <rect id="Rectangle" stroke="#306FFD" stroke-width="4" x="135" y="67" width="56" height="53.7705726" rx="2"></rect>
                 </g>
             </g>


### PR DESCRIPTION
When I first looked on the terminology page Grid track and Grid column looked almost the same for me, so I would suggest to adjust the color to make them more distinguishable