### PR TITLE
Update index.js

### DIFF
--- a/src/pages/debugger/index.js
+++ b/src/pages/debugger/index.js
@@ -28,8 +28,8 @@ const Tutorial = () => (
     <p>
       Before diving in, let’s take a look at the Debugger interface. Hit{' '}
       <span className="shortcut">option</span> + <span className="shortcut">command</span> +{' '}
-      <span className="shortcut">S</span> on Mac or <span className="shortcut">shift</span> +{' '}
-      <span className="shortcut">ctrl</span> + <span className="shortcut">S</span> on Windows to
+      <span className="shortcut">I</span> on Mac or <span className="shortcut">shift</span> +{' '}
+      <span className="shortcut">ctrl</span> + <span className="shortcut">I</span> on Windows to
       open the Debugger.{' '}
     </p>
     <p>The Debugger is divided into three panes:</p>


### PR DESCRIPTION
On the version of Mozilla Firefox I recently downloaded, shift-ctrl-S has been taken over by a print screen function. After some experimentation, I found the default hotkey for debugging tools is shift-ctrl-I by default, at least on Firefox Developers edition v. 95.0b8 (64-bit) for Windows.

(My first pull request. If it was unhelpful, a brief rejection would be appreciated so I can learn. OTOH I realize that people do not have time to correspond over each request and should not be expected to.)